### PR TITLE
imports unit test

### DIFF
--- a/go/membufc/compile_imports_test.go
+++ b/go/membufc/compile_imports_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"testing"
+	"bytes"
+	"github.com/orbs-network/pbparser"
+	"go/token"
+	"go/parser"
+	"go/ast"
+	"go/format"
+	"fmt"
+)
+
+func TestCompilingEmptyProto(t *testing.T) {
+	proto := pbparser.ProtoFile{
+		PackageName: "foo",
+	}
+
+	compiled, err := compile(proto)
+	if err != nil {
+		t.Fatalf("Parsing compiled file has failed: %s", err)
+	}
+
+	if compiled.Name.Name != "foo" {
+		t.Fatalf("Package name was '%s' and not 'foo'", compiled.Name.Name)
+	}
+
+	if len(compiled.Imports) > 0 {
+		t.Fatalf("Expected 0 imports, got %s", importsToString(compiled.Imports))
+	}
+}
+
+func TestCompilingProtoWithMessage(t *testing.T) {
+	stringType, _ := pbparser.NewScalarDataType("string")
+	proto := pbparser.ProtoFile{
+		PackageName: "foo",
+		Messages: []pbparser.MessageElement{
+			{
+				Name: "FooMessage",
+				Fields: []pbparser.FieldElement{
+					{
+						Name: "aString",
+						Type: stringType,
+						Tag:  1,
+					},
+				},
+			},
+		},
+	}
+
+	compiled, err := compile(proto)
+	if err != nil {
+		t.Fatalf("Parsing compiled file has failed: %s", err)
+	}
+
+	assertImport(t, "bytes", compiled)
+	assertImport(t, "fmt", compiled)
+	assertImport(t, "github.com/orbs-network/membuffers/go", compiled)
+}
+
+func assertImport(t *testing.T, importName string, compiled *ast.File) {
+	if !hasImport(compiled, importName) {
+		t.Fatalf("Expected '%s' import, got %s", importName, importsToString(compiled.Imports))
+	}
+}
+
+func hasImport(compiled *ast.File, importName string) bool {
+	for _, spec := range compiled.Imports {
+		if spec.Path.Value == fmt.Sprintf("\"%s\"", importName) {
+			return true
+		}
+	}
+	return false
+}
+
+func compile(proto pbparser.ProtoFile) (*ast.File, error) {
+	w := bytes.Buffer{}
+	compileProtoFile(&w, proto, make(map[string]dependencyData), MEMBUFC_VERSION)
+	fset := token.NewFileSet()
+	compiled, err := parser.ParseFile(fset, "", w.String(), parser.ImportsOnly)
+	return compiled, err
+}
+
+func importsToString(specs []*ast.ImportSpec) string {
+	w := bytes.Buffer{}
+	fset := token.NewFileSet()
+	for i, spec := range specs {
+		format.Node(&w, fset, spec)
+		if i < len(specs) - 1 {
+			w.WriteByte(',')
+		}
+	}
+
+	return w.String()
+}

--- a/go/membufc/test_compiler.sh
+++ b/go/membufc/test_compiler.sh
@@ -1,3 +1,5 @@
+go test .
+
 go run *.go -m `find . -name "*.proto"`
 go test ./e2e
 


### PR DESCRIPTION
added a unit test for the compiler, asserting that imports are added to protos with messages and no imports are added to protos without messages

TODO: add a test for a service without messages